### PR TITLE
Fix undefined reference errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-var React = require('react');
+const React = require('react');
 // not ideal, but doesn't properly load codemirror
 // currently looking for a better solution
-var SimpleMDE = require('simplemde/dist/simplemde.min');
-var $ = require('jquery');
+const SimpleMDE = require('simplemde/dist/simplemde.min');
+const $ = require('jquery');
 
-let state = {
+const state = {
   previousValue: null
 }
 


### PR DESCRIPTION
I have no exact idea why this is happening (whether it has to do something with React or it's in JS nature), but I am getting `undefined reference` errors for the modules imported, inside the object which we are passing to React.createClass. Setting these variables with `const` instead of `var` fixes these errors.
